### PR TITLE
BASW-646: Fix PostCodeEverywhere fields mapping

### DIFF
--- a/CRM/Civicrmpostcodelookup/Page/PostcodeAnywhere.php
+++ b/CRM/Civicrmpostcodelookup/Page/PostcodeAnywhere.php
@@ -119,6 +119,7 @@ class CRM_Civicrmpostcodelookup_Page_PostcodeAnywhere extends CRM_Civicrmpostcod
     $addressItem = (array) $addressItemRow['Row'];
 
     $addressLineArray[] = $addressItem['@attributes']['Company'];
+    $addressLineArray[] = $addressItem['@attributes']['SubBuilding'];
     $addressLineArray[] = $addressItem['@attributes']['Line1'];
     $addressLineArray[] = $addressItem['@attributes']['Line2'];
     $addressLineArray[] = $addressItem['@attributes']['Line3'];

--- a/info.xml
+++ b/info.xml
@@ -19,6 +19,7 @@
   <compatibility>
     <ver>5.19</ver>
   </compatibility>
+  <comments>Patch 1</comments>
   <comments>Developed by Veda NFP Consulting LTD.</comments>
   <civix>
     <namespace>CRM/Civicrmpostcodelookup</namespace>

--- a/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
+++ b/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
@@ -119,8 +119,12 @@
       var streetAddressElement = '#' + blockPrefix + 'street_address-'+ blockNo;
       var AddstreetAddressElement = '#' + blockPrefix + 'supplemental_address_1-'+ blockNo;
       var AddstreetAddressElement1 = '#' + blockPrefix + 'supplemental_address_2-'+ blockNo;
+      var AddstreetAddressElement2 = '#' + blockPrefix + 'supplemental_address_3-'+ blockNo;
       var cityElement = '#' + blockPrefix + 'city-'+ blockNo;
-      var countyElement = '#address_'+ blockNo +'_state_province_id';
+      var countyElement = '#' + blockPrefix +'state_province-'+ blockNo;
+      if(cj('#' + blockPrefix +'state_province_id-'+ blockNo).length) {
+        countyElement =  '#' + blockPrefix +'state_province_id-'+ blockNo;
+      }
 
       var allFields = {
         postcode: postcodeElement,
@@ -141,6 +145,53 @@
         }
       }
       else {
+        if(typeof address.supplemental_address_3 == 'undefined')
+          address.supplemental_address_3 = '';
+        var addr = [];
+        if(address.supplemental_address_1.length == 0 &&
+                address.supplemental_address_2.length == 0 &&
+                address.supplemental_address_3.length == 0) {
+          addr = address.street_address.split(",");
+          if(addr.length) {
+            address.street_address = addr.shift();
+          }
+          if(addr.length) {
+            address.supplemental_address_1 = addr.shift();
+          }
+          if(addr.length) {
+            address.supplemental_address_2 = addr.shift();
+          }
+          if(addr.length) {
+            address.supplemental_address_3 = addr.join(', ');
+          }
+        }
+        else if (address.supplemental_address_2.length == 0 &&
+                address.supplemental_address_3.length == 0) {
+          addr = address.street_address.split(",");
+          if(addr.length) {
+            address.street_address = addr.shift();
+          }
+          if(addr.length) {
+            address.supplemental_address_2 = address.supplemental_address_1;
+            address.supplemental_address_1 = addr.shift();
+          }
+          if(addr.length) {
+            address.supplemental_address_3 = address.supplemental_address_2;
+            address.supplemental_address_2 = addr.join(', ');
+          }
+        }
+        else if (address.supplemental_address_3.length == 0) {
+          addr = address.street_address.split(",");
+          if(addr.length) {
+            address.street_address = addr.shift();
+          }
+          if(addr.length) {
+            address.supplemental_address_3 = address.supplemental_address_2;
+            address.supplemental_address_2 = address.supplemental_address_1;
+            address.supplemental_address_1 = addr.join(', ');
+          }
+        }
+
         $(streetAddressElement).val('');
         $(AddstreetAddressElement).val('');
         $(AddstreetAddressElement1).val('');
@@ -151,6 +202,7 @@
         $(streetAddressElement).val(address.street_address);
         $(AddstreetAddressElement).val(address.supplemental_address_1);
         $(AddstreetAddressElement1).val(address.supplemental_address_2);
+        $(AddstreetAddressElement2).val(address.supplemental_address_3);
         $(cityElement).val(address.town);
         $(postcodeElement).val(address.postcode);
         if (typeof(address.state_province_id) !== 'undefined' && address.state_province_id !== null) {

--- a/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
@@ -114,6 +114,7 @@
     var streetAddressElement = '#address_'+ blockNo +'_street_address';
     var AddstreetAddressElement = '#address_'+ blockNo +'_supplemental_address_1';
     var AddstreetAddressElement1 = '#address_'+ blockNo +'_supplemental_address_2';
+    var AddstreetAddressElement2 = '#address_'+ blockNo +'_supplemental_address_3';
     var cityElement = '#address_'+ blockNo +'_city';
     var countyElement = '#address_'+ blockNo +'_state_province_id';
 
@@ -136,6 +137,53 @@
       }
     }
     else {
+      if(typeof address.supplemental_address_3 == 'undefined')
+        address.supplemental_address_3 = '';
+      var addr = [];
+      if(address.supplemental_address_1.length == 0 &&
+              address.supplemental_address_2.length == 0 &&
+              address.supplemental_address_3.length == 0) {
+        addr = address.street_address.split(",");
+        if(addr.length) {
+          address.street_address = addr.shift();
+        }
+        if(addr.length) {
+          address.supplemental_address_1 = addr.shift();
+        }
+        if(addr.length) {
+          address.supplemental_address_2 = addr.shift();
+        }
+        if(addr.length) {
+          address.supplemental_address_3 = addr.join(', ');
+        }
+      }
+      else if (address.supplemental_address_2.length == 0 &&
+              address.supplemental_address_3.length == 0) {
+        addr = address.street_address.split(",");
+        if(addr.length) {
+          address.street_address = addr.shift();
+        }
+        if(addr.length) {
+          address.supplemental_address_2 = address.supplemental_address_1;
+          address.supplemental_address_1 = addr.shift();
+        }
+        if(addr.length) {
+          address.supplemental_address_3 = address.supplemental_address_2;
+          address.supplemental_address_2 = addr.join(', ');
+        }
+      }
+      else if (address.supplemental_address_3.length == 0) {
+        addr = address.street_address.split(",");
+        if(addr.length) {
+          address.street_address = addr.shift();
+        }
+        if(addr.length) {
+          address.supplemental_address_3 = address.supplemental_address_2;
+          address.supplemental_address_2 = address.supplemental_address_1;
+          address.supplemental_address_1 = addr.join(', ');
+        }
+      }
+
       cj(streetAddressElement).val('');
       cj(AddstreetAddressElement).val('');
       cj(AddstreetAddressElement1).val('');
@@ -146,6 +194,7 @@
       cj(streetAddressElement).val(address.street_address);
       cj(AddstreetAddressElement).val(address.supplemental_address_1);
       cj(AddstreetAddressElement1).val(address.supplemental_address_2);
+      cj(AddstreetAddressElement2).val(address.supplemental_address_3);
       cj(cityElement).val(address.town);
       cj(postcodeElement).val(address.postcode);
       if(typeof(address.state_province_id) != "undefined" && address.state_province_id !== null) {


### PR DESCRIPTION
This is just patching the work done originaly by Vinu as part of two tickets which are : 

- BASW-70
- BASW-235
See : https://github.com/compucorp/uk.co.vedaconsulting.module.civicrmpostcodelookup/pull/2 commits


The work aims to fix and improving address mapping when using PostCodeAnywhere provider, mainly to match the following document : https://docs.google.com/spreadsheets/d/1LBarzr2-LP1SAb2WdU5_oWPmmAq4QY35yQwGr5qTH7U/edit#gid=0



