### PR TITLE
BASW-646: Change PostCodeEverywhere address mapping

### DIFF
--- a/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
+++ b/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
@@ -10,6 +10,10 @@
     // Location Types from settings
     if (locationTypes) {
       $.each(locationTypes, function (id, index) {
+        if (index == 'Primary') {
+          id = 'Primary';
+        }
+
         addressSelector = '#editrow-street_address-' + id;
         if ($(addressSelector).length > 0) {
           blockId = id;

--- a/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
+++ b/templates/CRM/Civicrmpostcodelookup/Form/Postcodelookup.tpl
@@ -119,14 +119,19 @@
       var streetAddressElement = '#' + blockPrefix + 'street_address-'+ blockNo;
       var AddstreetAddressElement = '#' + blockPrefix + 'supplemental_address_1-'+ blockNo;
       var AddstreetAddressElement1 = '#' + blockPrefix + 'supplemental_address_2-'+ blockNo;
+      var AddstreetAddressElement2 = '#' + blockPrefix + 'supplemental_address_3-'+ blockNo;
       var cityElement = '#' + blockPrefix + 'city-'+ blockNo;
-      var countyElement = '#address_'+ blockNo +'_state_province_id';
+      var countyElement = '#' + blockPrefix +'state_province-'+ blockNo;
+      if(cj('#' + blockPrefix +'state_province_id-'+ blockNo).length) {
+        countyElement =  '#' + blockPrefix +'state_province_id-'+ blockNo;
+      }
 
       var allFields = {
         postcode: postcodeElement,
         line1: streetAddressElement,
         line2: AddstreetAddressElement,
         line3: AddstreetAddressElement1,
+        line4: AddstreetAddressElement2,
         city: cityElement
       };
 
@@ -144,6 +149,7 @@
         $(streetAddressElement).val('');
         $(AddstreetAddressElement).val('');
         $(AddstreetAddressElement1).val('');
+        $(AddstreetAddressElement2).val('');
         $(cityElement).val('');
         $(postcodeElement).val('');
         $(countyElement).val('');
@@ -151,6 +157,7 @@
         $(streetAddressElement).val(address.street_address);
         $(AddstreetAddressElement).val(address.supplemental_address_1);
         $(AddstreetAddressElement1).val(address.supplemental_address_2);
+        $(AddstreetAddressElement2).val(address.supplemental_address_3);
         $(cityElement).val(address.town);
         $(postcodeElement).val(address.postcode);
         if (typeof(address.state_province_id) !== 'undefined' && address.state_province_id !== null) {
@@ -162,6 +169,7 @@
         $(streetAddressElement).trigger("change");
         $(AddstreetAddressElement).trigger("change");
         $(AddstreetAddressElement1).trigger("change");
+        $(AddstreetAddressElement2).trigger("change");
         $(cityElement).trigger("change");
         $(postcodeElement).trigger("change");
         $(countyElement).trigger("change");

--- a/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
@@ -114,6 +114,7 @@
     var streetAddressElement = '#address_'+ blockNo +'_street_address';
     var AddstreetAddressElement = '#address_'+ blockNo +'_supplemental_address_1';
     var AddstreetAddressElement1 = '#address_'+ blockNo +'_supplemental_address_2';
+    var AddstreetAddressElement2 = '#address_'+ blockNo +'_supplemental_address_3';
     var cityElement = '#address_'+ blockNo +'_city';
     var countyElement = '#address_'+ blockNo +'_state_province_id';
 
@@ -122,6 +123,7 @@
       line1: streetAddressElement,
       line2: AddstreetAddressElement,
       line3: AddstreetAddressElement1,
+      line4: AddstreetAddressElement2,
       city: cityElement
     };
 
@@ -139,6 +141,7 @@
       cj(streetAddressElement).val('');
       cj(AddstreetAddressElement).val('');
       cj(AddstreetAddressElement1).val('');
+      cj(AddstreetAddressElement2).val('');
       cj(cityElement).val('');
       cj(postcodeElement).val('');
       cj(countyElement).val('');
@@ -146,6 +149,7 @@
       cj(streetAddressElement).val(address.street_address);
       cj(AddstreetAddressElement).val(address.supplemental_address_1);
       cj(AddstreetAddressElement1).val(address.supplemental_address_2);
+      cj(AddstreetAddressElement2).val(address.supplemental_address_3);
       cj(cityElement).val(address.town);
       cj(postcodeElement).val(address.postcode);
       if(typeof(address.state_province_id) != "undefined" && address.state_province_id !== null) {


### PR DESCRIPTION
## Overview

When PostCodeEverywhere provider is used, we need the mapping to following this document : 

https://docs.google.com/spreadsheets/d/1LBarzr2-LP1SAb2WdU5_oWPmmAq4QY35yQwGr5qTH7U/edit#gid=0

## Before

The original work was done here : https://github.com/compucorp/uk.co.vedaconsulting.module.civicrmpostcodelookup/pull/2 (see the commits) but it turned out that it is not working well for some cases (example codes AL3 8QE and  LU1 1QE).

## After

The mapping is changed to follow this document more accuratly : 

https://docs.google.com/spreadsheets/d/1LBarzr2-LP1SAb2WdU5_oWPmmAq4QY35yQwGr5qTH7U/edit#gid=0


If the company from PostCodeEverywhere  API is empty then it will shift the values and the street
address will become Line 1 if Line 1 is not empty and so on, This shift apply to all the  other  address fields.

another fix in this PR that ensure that state field is populated when used on pages such as event registration public pages.