### PR TITLE
Merge 7.0.0-alpha1-rc back to 1.14-patches after release 7.0.0-alpha1

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -13,7 +13,7 @@
     <url desc="Support">https://lab.civicrm.org/extensions/ukpostcodes/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2026-01-20</releaseDate>
+  <releaseDate>2026-01-21</releaseDate>
   <version>7.0.0-alpha1</version>
   <develStage>stable</develStage>
   <compatibility>

--- a/info.xml
+++ b/info.xml
@@ -13,7 +13,7 @@
     <url desc="Support">https://lab.civicrm.org/extensions/ukpostcodes/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-05-30</releaseDate>
+  <releaseDate>2026-01-20</releaseDate>
   <version>7.0.0-alpha1</version>
   <develStage>stable</develStage>
   <compatibility>

--- a/info.xml
+++ b/info.xml
@@ -13,7 +13,7 @@
     <url desc="Support">https://lab.civicrm.org/extensions/ukpostcodes/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2026-01-21</releaseDate>
+  <releaseDate>2026-01-22</releaseDate>
   <version>7.0.0-alpha1</version>
   <develStage>stable</develStage>
   <compatibility>

--- a/info.xml
+++ b/info.xml
@@ -14,7 +14,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2024-05-30</releaseDate>
-  <version>1.14</version>
+  <version>7.0.0-alpha1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.68</ver>


### PR DESCRIPTION
## Overview
- Merge RC branch changes back to 1.14-patches after release 7.0.0-alpha1
- This PR contains bug fixes and changes made during the RC phase

🤖 Generated by Compuclient release automation