### PR TITLE
COMCL-1433: Fix Address Fields

### DIFF
--- a/js/ukpostcodelookup.js
+++ b/js/ukpostcodelookup.js
@@ -121,23 +121,36 @@
               $(countryElement).val(address.country_id).trigger('change');
             }
 
-            if (($(AddstreetAddressElement2).length === 0) && (typeof address.supplemental_address_3 !== 'undefined')) {
-              if (typeof address.supplemental_address_1 !== 'undefined') {
-                address.supplemental_address_1 = address.supplemental_address_1 + ', ';
+            // Helper to join address line parts, skipping any that are undefined/null/empty.
+            // Avoids stray ", " separators and prevents in-place mutation of source values.
+            var joinAddressParts = function () {
+              var parts = [];
+              for (var i = 0; i < arguments.length; i++) {
+                var v = arguments[i];
+                if (typeof v !== 'undefined' && v !== null && v !== '') {
+                  parts.push(v);
+                }
               }
-              if (typeof address.supplemental_address_2 !== 'undefined') {
-                address.supplemental_address_2 = address.supplemental_address_2 + ', ';
-              }
-              address.supplemental_address_2 = address.supplemental_address_1 + address.supplemental_address_2 + address.supplemental_address_3;
+              return parts.join(', ');
+            };
+
+            // If the Address Line 4 (supplemental_address_3) field is not on the form,
+            // fold its value up into supplemental_address_2.
+            if (($(AddstreetAddressElement2).length === 0) && (typeof address.supplemental_address_3 !== 'undefined') && address.supplemental_address_3 !== '') {
+              address.supplemental_address_2 = joinAddressParts(address.supplemental_address_2, address.supplemental_address_3);
+              address.supplemental_address_3 = '';
             }
-            if (($(AddstreetAddressElement1).length === 0) && (typeof address.supplemental_address_2 !== 'undefined')) {
-              if (typeof address.supplemental_address_1 !== 'undefined') {
-                address.supplemental_address_1 = address.supplemental_address_1 + ', ';
-              }
-              address.supplemental_address_1 = address.supplemental_address_1 + address.supplemental_address_2;
+            // If the Address Line 3 (supplemental_address_2) field is not on the form,
+            // fold its value up into supplemental_address_1.
+            if (($(AddstreetAddressElement1).length === 0) && (typeof address.supplemental_address_2 !== 'undefined') && address.supplemental_address_2 !== '') {
+              address.supplemental_address_1 = joinAddressParts(address.supplemental_address_1, address.supplemental_address_2);
+              address.supplemental_address_2 = '';
             }
-            if (($(AddstreetAddressElement).length === 0) && (typeof address.supplemental_address_1 !== 'undefined')) {
-              address.street_address = address.street_address + ', ' + address.supplemental_address_1;
+            // If the Address Line 2 (supplemental_address_1) field is not on the form,
+            // fold its value up into street_address.
+            if (($(AddstreetAddressElement).length === 0) && (typeof address.supplemental_address_1 !== 'undefined') && address.supplemental_address_1 !== '') {
+              address.street_address = joinAddressParts(address.street_address, address.supplemental_address_1);
+              address.supplemental_address_1 = '';
             }
 
             $(streetAddressElement).val(address.street_address);


### PR DESCRIPTION
## Overview
When using the postcode lookup during event registration (and likely other CiviCRM forms that only expose a subset of address lines), **Address Line 2** was being populated with a corrupted value — it contained **Supplemental Address 1 repeated twice**, plus Supplemental Address 2, along with stray commas. Whatever the user saw in the field was then saved to CiviCRM as-is, so the bad data ended up persisted on the contact's address record.

The event registration profile typically only exposes `street_address` (Line 1) and `supplemental_address_1` (Line 2), even though the postcode lookup provider may return up to 4 address lines. The JavaScript in the `uk.co.vedaconsulting.module.civicrmpostcodelookup` extension is supposed to "fold" the extra lines upward into the available fields so no data is lost — but the folding logic was buggy.

## Technical Details

Two bugs in the collapse block inside `setAddressFields()` in `js/ukpostcodelookup.js` interacted to produce the broken output.

### Bug 1 — `typeof x !== 'undefined'` treats empty strings as defined values

`CRM/Civicrmpostcodelookup/Page/PostcodeAnywhere.php` always returns `supplemental_address_3` in the JSON payload, initialising it to an empty string when the provider has no fourth line. An empty string passes that check, so the code appended a literal `", "` to empty values. This produced the stray commas observed in the output.

### Bug 2 — source values were mutated in place, then reused downstream

The original code mutated `address.supplemental_address_1` (appending `", "`), used it to build `supplemental_address_2`, and then — on the next conditional — mutated `supplemental_address_1` **again** by concatenating the already-rebuilt `supplemental_address_2` onto it. Because `supplemental_address_2` now contained the original `supplemental_address_1`, the value got pulled in a second time.

### Fix

Replaced the collapse block with a small helper plus three conditional folds.

## Before
<img width="1792" height="1120" alt="Screenshot 2026-04-21 at 10 19 10 PM" src="https://github.com/user-attachments/assets/0fa438e9-7963-490b-b623-1a687bb35b59" />

## After
<img width="1792" height="1120" alt="Screenshot 2026-04-21 at 10 22 38 PM" src="https://github.com/user-attachments/assets/d4e378bf-92a9-4dbc-b283-0d38a004949f" />

